### PR TITLE
Add extra output to show why dates need to be input

### DIFF
--- a/BookTracker/src/main/java/Plugin/Application/ConsoleCommands/EditReadingArchive/AddReadingListEntryToReadingArchive.java
+++ b/BookTracker/src/main/java/Plugin/Application/ConsoleCommands/EditReadingArchive/AddReadingListEntryToReadingArchive.java
@@ -33,7 +33,9 @@ public class AddReadingListEntryToReadingArchive implements ConsoleCommand {
             case 1 -> readingListEntry = results.get(0);
             default -> readingListEntry = Input.promptUserForListChoice(results);
         }
+        System.out.println("Geben Sie das Startdatum an");
         BookDateWrapper startDate = Input.promptUserForDate();
+        System.out.println("Geben Sie das Enddatum an");
         BookDateWrapper endDate = Input.promptUserForDate();
         String comment = Input.promptMsg("Notiz oder Kommentar?");
         if (comment.isEmpty()) {


### PR DESCRIPTION
As stated in https://github.com/Leonneu/BookTracker/issues/2#issue-2576811390, people are not sure why dates need to be provided.
This PR adds extra output to show why dates need to be provided.