### PR TITLE
corrected spelling Mistake 'Keine Buch' --> 'Kein Buch'

### DIFF
--- a/BookTracker/src/main/java/Plugin/Application/ConsoleCommands/EditReadingArchive/AddReadingListEntryToReadingArchive.java
+++ b/BookTracker/src/main/java/Plugin/Application/ConsoleCommands/EditReadingArchive/AddReadingListEntryToReadingArchive.java
@@ -27,7 +27,7 @@ public class AddReadingListEntryToReadingArchive implements ConsoleCommand {
         ReadingListEntry readingListEntry;
         switch (results.size()) {
             case 0 -> {
-                Output.showOutput("Keine Buch mit diesem Titel in der Leseliste");
+                Output.showOutput("Kein Buch mit diesem Titel in der Leseliste");
                 return State.EDITREADINGARCHIVE;
             }
             case 1 -> readingListEntry = results.get(0);


### PR DESCRIPTION
There was a minor spelling mistake in the console output. 
'Keine Buch" --> 'Kein Buch'